### PR TITLE
Don't use FQN for the DB field name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ class MyDataClass extends DataObject
 {
 
     private static $db = array(
-		'MarkdownContent'		=> '\SilverStripers\markdown\db\MarkdownText'
+		'MarkdownContent'		=> 'MarkdownText'
 	);
 
 }

--- a/_config/model.yml
+++ b/_config/model.yml
@@ -1,0 +1,7 @@
+---
+Name: markdownfieldtype
+---
+
+SilverStripe\Core\Injector\Injector:
+  MarkdownText:
+    class: SilverStripers\markdown\db\MarkdownText


### PR DESCRIPTION
you can use `MarkdownText` in $db array rather than `\SilverStripers\markdown\db\MarkdownText`

eg:
```
private static $db = array(
    'MarkdownContent'		=> 'MarkdownText'
);
```
