### PR TITLE
Minor code cleanups and removal of duplicate code or unused code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ To use the markdown DB field in your data objects the basic code would look like
 class MyDataClass extends DataObject
 {
 
-    private static $db = array(
+    private static $db = [
 		'MarkdownContent'		=> 'MarkdownText'
-	);
+	];
 
 }
 
@@ -41,9 +41,9 @@ public function getCMSFields()
 {
     $fields = parent::getCMSFields();
 
-    $fields->addFieldsToTab('Root.Sidebar', array(
+    $fields->addFieldsToTab('Root.Sidebar', [
         \SilverStripers\markdown\forms\MarkdownEditorField::create('MarkdownContent', 'Content'),
-    ));
+    ]);
 
     return $fields;
 }

--- a/_config.php
+++ b/_config.php
@@ -7,22 +7,24 @@
  * To change this template use File | Settings | File Templates.
  */
 
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Config\Config;
+use SilverStripers\markdown\db\MarkdownText;
 use SilverStripers\markdown\shortcodes\MarkdownImageShortcodeProvider;
 use SilverStripe\Assets\Shortcodes\FileShortcodeProvider;
 use SilverStripe\Assets\Shortcodes\ImageShortcodeProvider;
 use SilverStripe\View\Parsers\ShortcodeParser;
 
-$asBase = \SilverStripe\Core\Config\Config::inst()->get(\SilverStripers\markdown\db\MarkdownText::class, 'markdown_as_base');
-if($asBase) {
-	$siteTreeDB = \SilverStripe\Core\Config\Config::inst()->get(\SilverStripe\CMS\Model\SiteTree::class, 'db');
-	$siteTreeDB['Content'] = \SilverStripers\markdown\db\MarkdownText::class;
-	\SilverStripe\Core\Config\Config::modify()
-		->set(\SilverStripe\CMS\Model\SiteTree::class, 'db', $siteTreeDB);
+$asBase = Config::inst()->get(MarkdownText::class, 'markdown_as_base');
+if ($asBase) {
+    $siteTreeDB = Config::inst()->get(SiteTree::class, 'db');
+    $siteTreeDB['Content'] = MarkdownText::class;
+    Config::modify()
+        ->set(SiteTree::class, 'db', $siteTreeDB);
 }
 
 
 ShortcodeParser::get('default')
-	->register('image', [ImageShortcodeProvider::class, 'handle_shortcode'])
-	->register('image_link', [MarkdownImageShortcodeProvider::class, 'handle_shortcode'])
-	->register('file_link', [FileShortcodeProvider::class, 'handle_shortcode']);
-
+    ->register('image', [ImageShortcodeProvider::class, 'handle_shortcode'])
+    ->register('image_link', [MarkdownImageShortcodeProvider::class, 'handle_shortcode'])
+    ->register('file_link', [FileShortcodeProvider::class, 'handle_shortcode']);

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,4 +6,4 @@ SilverStripe\Admin\LeftAndMain:
     - SilverStripers\markdown\extensions\MarkdownFieldExtension
 SilverStripe\CMS\Model\SiteTree:
   extensions:
-   - SilverStripers\markdown\extensions\MarkdownSiteTreeExtension
+    - SilverStripers\markdown\extensions\MarkdownSiteTreeExtension

--- a/src/db/MarkdownText.php
+++ b/src/db/MarkdownText.php
@@ -6,47 +6,51 @@
  * Time: 11:11 AM
  * To change this template use File | Settings | File Templates.
  */
+
 namespace SilverStripers\markdown\db;
 
-
-
-use SilverStripe\Forms\TextField;
-use SilverStripe\View\Parsers\ShortcodeParser;
 use cebe\markdown\GithubMarkdown;
-use SilverStripers\markdown\MarkdownEditorField;
+use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\NullableField;
+use SilverStripe\Forms\TextareaField;
+use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\FieldType\DBText;
+use SilverStripe\View\Parsers\ShortcodeParser;
+use SilverStripers\markdown\forms\MarkdownEditorField;
 
-class MarkdownText extends \SilverStripe\ORM\FieldType\DBText
+class MarkdownText extends DBText
 {
-
     private static $escape_type = 'xml';
 
-    private static $casting = array(
-        "AbsoluteLinks"         => "HTMLText",
-        "BigSummary"            => "HTMLText",
-        "ContextSummary" => "HTMLText",
-        "FirstParagraph" => "HTMLText",
-        "FirstSentence" => "HTMLText",
-        "LimitCharacters" => "HTMLText",
-        "LimitSentences" => "HTMLText",
-        "Lower" => "HTMLText",
-        "LowerCase" => "HTMLText",
-        "Summary" => "HTMLText",
-        "Upper" => "HTMLText",
-        "UpperCase" => "HTMLText",
-        'EscapeXML' => 'HTMLText',
-        'LimitWordCount' => 'HTMLText',
+    private static $casting = [
+        'AbsoluteLinks'     => 'HTMLText',
+        'BigSummary'        => 'HTMLText',
+        'ContextSummary'    => 'HTMLText',
+        'FirstParagraph'    => 'HTMLText',
+        'FirstSentence'     => 'HTMLText',
+        'LimitCharacters'   => 'HTMLText',
+        'LimitSentences'    => 'HTMLText',
+        'Lower'             => 'HTMLText',
+        'LowerCase'         => 'HTMLText',
+        'Summary'           => 'HTMLText',
+        'Upper'             => 'HTMLText',
+        'UpperCase'         => 'HTMLText',
+        'EscapeXML'         => 'HTMLText',
+        'LimitWordCount'    => 'HTMLText',
         'LimitWordCountXML' => 'HTMLText',
-        'NoHTML' => 'Text',
-    );
+        'NoHTML'            => 'Text',
+    ];
 
     private static $markdown_as_base = false;
-    
+
     private $parsedContent;
-    private $shortcodes = array();
+    private $shortcodes = [];
 
 
     /**
-     * @return string
+     * @param bool $bCache
+     * @param string $strValue
+     * @return string parse contents of the markdown field to tempates
      * parse contents of the markdown field to tempates
      */
     public function ParseMarkdown($bCache = true, $strValue = '')
@@ -57,24 +61,26 @@ class MarkdownText extends \SilverStripe\ORM\FieldType\DBText
 
         $parsed = !empty($strValue) ? $strValue : $this->value;
 
-        $this->shortcodes = array();
+        $this->shortcodes = [];
 
         // shortcodes
-        $regexes = array(
+        $regexes = [
             '/\[image_link*\s[a-z|A-Z|0-9\s\=]*\]/',
             '/\[file_link\,[a-z|A-Z|0-9\s\=]*\]/'
-        );
-        
+        ];
+
         foreach ($regexes as $pattern) {
             preg_match_all($pattern, $parsed, $matches);
-            if(!empty($matches[0])) foreach ($matches[0] as $attachment) {
-                $this->shortcodes[md5($attachment)] = $attachment;
-                $parsed = str_replace($attachment, md5($attachment), $parsed);
+            if (!empty($matches[0])) {
+                foreach ($matches[0] as $attachment) {
+                    $this->shortcodes[md5($attachment)] = $attachment;
+                    $parsed = str_replace($attachment, md5($attachment), $parsed);
+                }
             }
         }
 
         $parseDown = new GithubMarkdown();
-        $parsed  = $parseDown->parse($parsed);
+        $parsed = $parseDown->parse($parsed);
 
         foreach ($this->shortcodes as $key => $shortcode) {
             $parsed = str_replace($key, $shortcode, $parsed);
@@ -85,9 +91,9 @@ class MarkdownText extends \SilverStripe\ORM\FieldType\DBText
         $parsed = $shortCodeParser->parse($parsed);
 
         $this->parsedContent = $parsed;
+
         return $parsed;
     }
-
 
 
     /**
@@ -117,18 +123,6 @@ class MarkdownText extends \SilverStripe\ORM\FieldType\DBText
         return new MarkdownEditorField($this->name, $title);
     }
 
-
-    /**
-     * @param null $title
-     * @param null $params
-     * @return FormField|TextField
-     */
-    public function scaffoldSearchField($title = null, $params = null)
-    {
-        return new TextField($this->name, $title);
-    }
-
-
     /**
      * @return string
      */
@@ -143,6 +137,7 @@ class MarkdownText extends \SilverStripe\ORM\FieldType\DBText
     public function Upper()
     {
         $strValue = strtoupper($this->__toString());
+
         return $this->ParseMarkdown(false, $strValue);
     }
 
@@ -161,6 +156,7 @@ class MarkdownText extends \SilverStripe\ORM\FieldType\DBText
     public function Lower()
     {
         $strValue = strtolower($this->__toString());
+
         return $this->ParseMarkdown(false, $strValue);
     }
 

--- a/src/extensions/MarkdownFieldExtension.php
+++ b/src/extensions/MarkdownFieldExtension.php
@@ -9,18 +9,14 @@
 
 namespace SilverStripers\markdown\extensions;
 
-
 use SilverStripe\Core\Extension;
 use SilverStripe\View\Requirements;
 
 class MarkdownFieldExtension extends Extension
 {
-
-	public function init()
-	{
-		Requirements::javascript('silverstripers/silverstripe-markdown:client/dist/bundle.min.js');
-		Requirements::css('silverstripers/silverstripe-markdown:client/dist/bundle.min.css');
-
-	}
-
+    public function init()
+    {
+        Requirements::javascript('silverstripers/silverstripe-markdown:client/dist/bundle.min.js');
+        Requirements::css('silverstripers/silverstripe-markdown:client/dist/bundle.min.css');
+    }
 }

--- a/src/extensions/MarkdownSiteTreeExtension.php
+++ b/src/extensions/MarkdownSiteTreeExtension.php
@@ -8,7 +8,6 @@
 
 namespace SilverStripers\markdown\extensions;
 
-
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataExtension;
@@ -17,12 +16,13 @@ use SilverStripers\markdown\forms\MarkdownEditorField;
 
 class MarkdownSiteTreeExtension extends DataExtension
 {
-
+    /**
+     * @param FieldList $fields
+     */
     public function updateCMSFields(FieldList $fields)
     {
-        if(Config::inst()->get(MarkdownText::class, 'markdown_as_base')) {
+        if (Config::inst()->get(MarkdownText::class, 'markdown_as_base')) {
             $fields->replaceField('Content', MarkdownEditorField::create('Content'));
         }
     }
-
 }

--- a/src/forms/MarkdownEditorConfig.php
+++ b/src/forms/MarkdownEditorConfig.php
@@ -15,160 +15,178 @@ use SilverStripe\Core\Injector\Injectable;
 
 class MarkdownEditorConfig
 {
-
-	use Configurable;
-	use Injectable;
-
-
-	protected static $configs = array();
-	protected static $current = null;
-	private static $default_config = 'default';
-
-	protected $settings = array(
-		array(
-			'name'		=> 'heading',
-			'className'	=> 'fa fa-header',
-			'title'		=> 'Heading HTML',
-			'action'	=> 'toggleHeadingSmaller'
-		),
-		array(
-			'name'		=> 'bold',
-			'className'	=> 'fa fa-bold',
-			'title'		=> 'Bold',
-			'action'	=> 'toggleBold'
-		),
-		array(
-			'name'		=> 'italic',
-			'className'	=> 'fa fa-italic',
-			'title'		=> 'Italic',
-			'action'	=> 'toggleItalic'
-		),
-		array(
-			'name'		=> 'strikethrough',
-			'className'	=> 'fa fa-strikethrough',
-			'title'		=> 'Strike Through',
-			'action'	=> 'toggleStrikethrough'
-		),
-		"|",
-		array(
-			'name'		=> 'quote',
-			'className'	=> 'fa fa-quote-left',
-			'title'		=> 'Quote',
-			'action'	=> 'toggleBlockquote'
-		),
-		array(
-			'name'		=> 'unordered-list',
-			'action'	=> 'toggleUnorderedList',
-			'className'	=> 'fa fa-list-ul',
-            'title'		=> 'Generic List'
-		),
-		array(
-			'name'		=> 'ordered-list',
-			'action'	=> 'toggleOrderedList',
-			'className'	=> 'fa fa-list-ol',
-            'title'		=> 'Ordered List'
-		),
-		array(
-			'name'		=> 'link',
-			'action'	=> 'drawLink',
-			'className'	=> 'fa fa-link',
-            'title'		=> 'Create Link'
-		),
-		array(
-			'name'		=> 'embed',
-			'action'	=> 'ssEmbed',
-			'className'	=> 'fa fa-play',
-            'title'		=> 'Embed Media'
-		),
-		array(
-			'name'		=> 'image',
-			'action'	=> 'ssImage',
-			'className'	=> 'fa fa-picture-o',
-            'title'		=> 'Insert Image'
-		),
-		'|',
-		array(
-			'name'		=> 'preview',
-			'action'	=> 'togglePreview',
-			'className'	=> 'fa fa-eye no-disable',
-			'title'		=> 'Toggle Preview'
-		),
-		array(
-			'name'		=> 'side-by-side',
-			'action'	=> 'toggleSideBySide',
-			'className'	=> 'fa fa-columns no-disable no-mobile',
-			'title'		=> 'Toggle Side by Side'
-		),
-		array(
-			'name'		=> 'fullscreen',
-			'action'	=> 'toggleFullScreen',
-			'className'	=> 'fa fa-arrows-alt no-disable no-mobile',
-			'title'		=> 'Toggle Fullscreen'
-		),
-		'|',
-		array(
-			'name'		=> 'guide',
-			'action'	=> 'https://simplemde.com/markdown-guide',
-			'className'	=> 'fa fa-question-circle',
-			'title'		=> 'Help'
-		)
-	);
+    use Configurable;
+    use Injectable;
 
 
+    protected static $configs = [];
+    protected static $current;
+    private static $default_config = 'default';
 
-	public static function get($identifier = null)
-	{
-		if (!$identifier) {
-			return static::get_active();
-		}
-		// Create new instance if unconfigured
-		if (!isset(self::$configs[$identifier])) {
-			self::$configs[$identifier] = static::create();
-		}
-		return self::$configs[$identifier];
-	}
+    protected $settings = [
+        [
+            'name'      => 'heading',
+            'className' => 'fa fa-header',
+            'title'     => 'Heading HTML',
+            'action'    => 'toggleHeadingSmaller'
+        ],
+        [
+            'name'      => 'bold',
+            'className' => 'fa fa-bold',
+            'title'     => 'Bold',
+            'action'    => 'toggleBold'
+        ],
+        [
+            'name'      => 'italic',
+            'className' => 'fa fa-italic',
+            'title'     => 'Italic',
+            'action'    => 'toggleItalic'
+        ],
+        [
+            'name'      => 'strikethrough',
+            'className' => 'fa fa-strikethrough',
+            'title'     => 'Strike Through',
+            'action'    => 'toggleStrikethrough'
+        ],
+        "|",
+        [
+            'name'      => 'quote',
+            'className' => 'fa fa-quote-left',
+            'title'     => 'Quote',
+            'action'    => 'toggleBlockquote'
+        ],
+        [
+            'name'      => 'unordered-list',
+            'action'    => 'toggleUnorderedList',
+            'className' => 'fa fa-list-ul',
+            'title'     => 'Generic List'
+        ],
+        [
+            'name'      => 'ordered-list',
+            'action'    => 'toggleOrderedList',
+            'className' => 'fa fa-list-ol',
+            'title'     => 'Ordered List'
+        ],
+        [
+            'name'      => 'link',
+            'action'    => 'drawLink',
+            'className' => 'fa fa-link',
+            'title'     => 'Create Link'
+        ],
+        [
+            'name'      => 'embed',
+            'action'    => 'ssEmbed',
+            'className' => 'fa fa-play',
+            'title'     => 'Embed Media'
+        ],
+        [
+            'name'      => 'image',
+            'action'    => 'ssImage',
+            'className' => 'fa fa-picture-o',
+            'title'     => 'Insert Image'
+        ],
+        '|',
+        [
+            'name'      => 'preview',
+            'action'    => 'togglePreview',
+            'className' => 'fa fa-eye no-disable',
+            'title'     => 'Toggle Preview'
+        ],
+        [
+            'name'      => 'side-by-side',
+            'action'    => 'toggleSideBySide',
+            'className' => 'fa fa-columns no-disable no-mobile',
+            'title'     => 'Toggle Side by Side'
+        ],
+        [
+            'name'      => 'fullscreen',
+            'action'    => 'toggleFullScreen',
+            'className' => 'fa fa-arrows-alt no-disable no-mobile',
+            'title'     => 'Toggle Fullscreen'
+        ],
+        '|',
+        [
+            'name'      => 'guide',
+            'action'    => 'https://simplemde.com/markdown-guide',
+            'className' => 'fa fa-question-circle',
+            'title'     => 'Help'
+        ]
+    ];
 
+    /**
+     * @param null $identifier
+     * @return mixed
+     */
+    public static function get($identifier = null)
+    {
+        if (!$identifier) {
+            return static::get_active();
+        }
+        // Create new instance if unconfigured
+        if (!isset(self::$configs[$identifier])) {
+            self::$configs[$identifier] = static::create();
+        }
 
-	public static function get_active_identifier()
-	{
-		$identifier = self::$current ?: static::config()->get('default_config');
-		return $identifier;
-	}
+        return self::$configs[$identifier];
+    }
 
-	public static function get_active()
-	{
-		$identifier = self::get_active_identifier();
-		return self::get($identifier);
-	}
+    /**
+     * @return mixed
+     */
+    public static function get_active_identifier()
+    {
+        return static::$current ?: static::config()->get('default_config');
+    }
 
-	public static function set_active(MarkdownEditorConfigs $config)
-	{
-		$identifier = static::get_active_identifier();
-		return static::set_config($identifier, $config);
-	}
+    /**
+     * @return mixed
+     */
+    public static function get_active()
+    {
+        return static::get_active_identifier();
+    }
 
-	public static function set_config($identifier, MarkdownEditorConfigs $config = null)
-	{
-		if ($config) {
-			self::$configs[$identifier] = $config;
-		} else {
-			unset(self::$configs[$identifier]);
-		}
-		return $config;
-	}
+    /**
+     * @param MarkdownEditorConfig $config
+     * @return MarkdownEditorConfig
+     */
+    public static function set_active(MarkdownEditorConfig $config)
+    {
+        return static::get_active_identifier();
+    }
 
-	public function getConfig()
-	{
-		return $this->settings;
-	}
+    /**
+     * @param $identifier
+     * @param MarkdownEditorConfig|null $config
+     * @return MarkdownEditorConfig
+     */
+    public static function set_config($identifier, MarkdownEditorConfig $config = null)
+    {
+        if ($config) {
+            static::$configs[$identifier] = $config;
+        } else {
+            unset(static::$configs[$identifier]);
+        }
 
-	public function getAttributes()
-	{
-		return [
-			'data-editor' => 'markDown',
-			'data-config' => Convert::array2json($this->getConfig()),
-		];
-	}
+        return $config;
+    }
 
+    /**
+     * @return array
+     */
+    public function getConfig()
+    {
+        return $this->settings;
+    }
 
+    /**
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return [
+            'data-editor' => 'markDown',
+            'data-config' => Convert::array2json($this->getConfig()),
+        ];
+    }
 }

--- a/src/forms/MarkdownEditorField.php
+++ b/src/forms/MarkdownEditorField.php
@@ -13,6 +13,7 @@ use SilverStripe\Forms\TextareaField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectInterface;
 use Exception;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\View\Parsers\HTMLValue;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorSanitiser;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
@@ -20,21 +21,27 @@ use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 
 class MarkdownEditorField extends TextareaField
 {
-
-    private static $allowed_actions = array(
+    private static $allowed_actions = [
         'preview'
-    );
+    ];
 
     protected $editorConfig = null;
 
     protected $rows = 30;
 
+    /**
+     * @param MarkdownEditorConfig $configs
+     * @return $this
+     */
     public function setEditorConfig(MarkdownEditorConfig $configs)
     {
         $this->editorConfig = $configs;
         return $this;
     }
 
+    /**
+     * @return mixed|null|MarkdownEditorConfig
+     */
     public function getEditorConfig()
     {
         // Instance override
@@ -45,6 +52,9 @@ class MarkdownEditorField extends TextareaField
         return MarkdownEditorConfig::get($this->editorConfig);
     }
 
+    /**
+     * @return array
+     */
     public function getAttributes()
     {
         $attributes = [];
@@ -55,15 +65,22 @@ class MarkdownEditorField extends TextareaField
         );
     }
 
-
-    public function Field($properties = array())
+    /**
+     * @param array $properties
+     * @return DBHTMLText
+     */
+    public function Field($properties = [])
     {
         return parent::Field($properties);
     }
 
+    /**
+     * @param DataObjectInterface $record
+     * @throws Exception
+     */
     public function saveInto(DataObjectInterface $record)
     {
-        if ($record->hasField($this->name) && $record->escapeTypeForField($this->name) != 'xml') {
+        if ($record->hasField($this->name) && $record->escapeTypeForField($this->name) !== 'xml') {
             throw new Exception(
                 'MarkdownEditorField->saveInto(): This field should save into a MarkdownText field.'
             );
@@ -73,7 +90,4 @@ class MarkdownEditorField extends TextareaField
         $this->extend('processHTML', $markdownValue);
         $record->{$this->name} = $markdownValue;
     }
-
-
-
 }

--- a/src/shortcodes/MarkdownImageShortcodeProvider.php
+++ b/src/shortcodes/MarkdownImageShortcodeProvider.php
@@ -15,69 +15,66 @@ use SilverStripe\View\Parsers\ShortcodeHandler;
 use SilverStripe\View\Parsers\ShortcodeParser;
 use SilverStripe\Assets\Shortcodes\FileShortcodeProvider;
 
-
 class MarkdownImageShortcodeProvider extends FileShortcodeProvider implements ShortcodeHandler
 {
+    public static function get_shortcodes()
+    {
+        return ['image_link'];
+    }
 
-	public static function get_shortcodes()
-	{
-		return array('image_link');
-	}
+    public static function handle_shortcode($args, $content, $parser, $shortcode, $extra = [])
+    {
+        // Find appropriate record, with fallback for error handlers
+        $record = static::find_shortcode_record($args, $errorCode);
+        if ($errorCode) {
+            $record = static::find_error_record($errorCode);
+        }
+        if (!$record) {
+            return null;
+        }
 
-	public static function handle_shortcode($args, $content, $parser, $shortcode, $extra = array())
-	{
-		// Find appropriate record, with fallback for error handlers
-		$record = static::find_shortcode_record($args, $errorCode);
-		if ($errorCode) {
-			$record = static::find_error_record($errorCode);
-		}
-		if (!$record) {
-			return null;
-		}
+        $src = $record->Link();
+        if ($record instanceof Image) {
+            $width = isset($args['width']) ? $args['width'] : null;
+            $height = isset($args['height']) ? $args['height'] : null;
+            $hasCustomDimensions = ($width && $height);
+            if ($hasCustomDimensions && (($width != $record->getWidth()) || ($height != $record->getHeight()))) {
+                $resized = $record->ResizedImage($width, $height);
+                // Make sure that the resized image actually returns an image
+                if ($resized) {
+                    $src = $resized->getURL();
+                }
+            }
+        }
+        return $src;
+    }
 
-		$src = $record->Link();
-		if ($record instanceof Image) {
-			$width = isset($args['width']) ? $args['width'] : null;
-			$height = isset($args['height']) ? $args['height'] : null;
-			$hasCustomDimensions = ($width && $height);
-			if ($hasCustomDimensions && (($width != $record->getWidth()) || ($height != $record->getHeight()))) {
-				$resized = $record->ResizedImage($width, $height);
-				// Make sure that the resized image actually returns an image
-				if ($resized) {
-					$src = $resized->getURL();
-				}
-			}
-		}
-		return $src;
-	}
+    public static function regenerate_shortcode($args, $content, $parser, $shortcode, $extra = [])
+    {
+        // Check if there is a suitable record
+        $record = static::find_shortcode_record($args);
+        if ($record) {
+            $args['src'] = $record->getURL();
+        }
 
-	public static function regenerate_shortcode($args, $content, $parser, $shortcode, $extra = array())
-	{
-		// Check if there is a suitable record
-		$record = static::find_shortcode_record($args);
-		if ($record) {
-			$args['src'] = $record->getURL();
-		}
+        // Rebuild shortcode
+        $parts = [];
+        foreach ($args as $name => $value) {
+            $htmlValue = Convert::raw2att($value ?: $name);
+            $parts[] = sprintf('%s="%s"', $name, $htmlValue);
+        }
+        return sprintf("[%s %s]", $shortcode, implode(' ', $parts));
+    }
 
-		// Rebuild shortcode
-		$parts = array();
-		foreach ($args as $name => $value) {
-			$htmlValue = Convert::raw2att($value ?: $name);
-			$parts[] = sprintf('%s="%s"', $name, $htmlValue);
-		}
-		return sprintf("[%s %s]", $shortcode, implode(' ', $parts));
-	}
-
-	/**
-	 * Helper method to regenerate all shortcode links.
-	 *
-	 * @param string $value HTML value
-	 * @return string value with links resampled
-	 */
-	public static function regenerate_html_links($value)
-	{
-		$regenerator = ShortcodeParser::get('regenerator');
-		return $regenerator->parse($value);
-	}
-
+    /**
+     * Helper method to regenerate all shortcode links.
+     *
+     * @param string $value HTML value
+     * @return string value with links resampled
+     */
+    public static function regenerate_html_links($value)
+    {
+        $regenerator = ShortcodeParser::get('regenerator');
+        return $regenerator->parse($value);
+    }
 }


### PR DESCRIPTION
- Removed unneeded/unused code
- Added docblocks to methods
- Added use statements instead of using inline FQN
- Ran PHP-CS-Fixer to make it PSR-2 compliant
- Changed all arrays to shorthand (preferred syntax, and more consistent over all)