### PR TITLE
change the HTMLText's class from injector to point to MarkdownText

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,20 @@ public function getCMSFields()
 }
 ```
 
-There is an option to completely replace the HTMLText fields from a CMS by using the following config
+## Force all teh fields to use Markdown
+
+If you are looking to replace all the fields of HTMLText to markdown use the following configs in the config.yml.
+
+This should override any instances of the HTMLText replacements with MarkdownText
 
 ```
-
-SilverStripers\markdown\db\MarkdownText:
-    markdown_as_base: true
-
+---
+Name: myconfigs
+After:
+  - '#corefieldtypes'
+---
+SilverStripe\Core\Injector\Injector:
+  HTMLText:
+    class: SilverStripers\markdown\db\MarkdownText
 ```
 

--- a/_config.php
+++ b/_config.php
@@ -6,18 +6,12 @@
  * Time: 11:21 AM
  * To change this template use File | Settings | File Templates.
  */
-
-use SilverStripe\Core\Config\Config;
-use SilverStripers\markdown\db\MarkdownText;
 use SilverStripers\markdown\shortcodes\MarkdownImageShortcodeProvider;
 use SilverStripe\Assets\Shortcodes\FileShortcodeProvider;
 use SilverStripe\Assets\Shortcodes\ImageShortcodeProvider;
 use SilverStripe\View\Parsers\ShortcodeParser;
 
-$asBase = Config::inst()->get(MarkdownText::class, 'markdown_as_base');
-if ($asBase) {
-    Config::modify('SilverStripe\Core\Injector\Injector', 'class', MarkdownText::class);
-}
+
 
 ShortcodeParser::get('default')
     ->register('image', [ImageShortcodeProvider::class, 'handle_shortcode'])

--- a/_config.php
+++ b/_config.php
@@ -7,7 +7,6 @@
  * To change this template use File | Settings | File Templates.
  */
 
-use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Config\Config;
 use SilverStripers\markdown\db\MarkdownText;
 use SilverStripers\markdown\shortcodes\MarkdownImageShortcodeProvider;
@@ -17,12 +16,8 @@ use SilverStripe\View\Parsers\ShortcodeParser;
 
 $asBase = Config::inst()->get(MarkdownText::class, 'markdown_as_base');
 if ($asBase) {
-    $siteTreeDB = Config::inst()->get(SiteTree::class, 'db');
-    $siteTreeDB['Content'] = MarkdownText::class;
-    Config::modify()
-        ->set(SiteTree::class, 'db', $siteTreeDB);
+    Config::modify('SilverStripe\Core\Injector\Injector', 'class', MarkdownText::class);
 }
-
 
 ShortcodeParser::get('default')
     ->register('image', [ImageShortcodeProvider::class, 'handle_shortcode'])

--- a/_config/model.yml
+++ b/_config/model.yml
@@ -5,3 +5,5 @@ Name: markdownfieldtype
 SilverStripe\Core\Injector\Injector:
   MarkdownText:
     class: SilverStripers\markdown\db\MarkdownText
+  HTMLText:
+    class: SilverStripers\markdown\db\MarkdownText

--- a/_config/model.yml
+++ b/_config/model.yml
@@ -5,5 +5,3 @@ Name: markdownfieldtype
 SilverStripe\Core\Injector\Injector:
   MarkdownText:
     class: SilverStripers\markdown\db\MarkdownText
-  HTMLText:
-    class: SilverStripers\markdown\db\MarkdownText

--- a/src/db/MarkdownText.php
+++ b/src/db/MarkdownText.php
@@ -41,8 +41,6 @@ class MarkdownText extends DBText
         'NoHTML'            => 'Text',
     ];
 
-    private static $markdown_as_base = false;
-
     private $parsedContent;
     private $shortcodes = [];
 

--- a/src/extensions/MarkdownSiteTreeExtension.php
+++ b/src/extensions/MarkdownSiteTreeExtension.php
@@ -11,6 +11,7 @@ namespace SilverStripers\markdown\extensions;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripers\markdown\db\MarkdownText;
 use SilverStripers\markdown\forms\MarkdownEditorField;
 
@@ -21,7 +22,8 @@ class MarkdownSiteTreeExtension extends DataExtension
      */
     public function updateCMSFields(FieldList $fields)
     {
-        if (Config::inst()->get(MarkdownText::class, 'markdown_as_base')) {
+        $injectorConfig = Config::inst()->get(Injector::class, 'HTMLText');
+        if ($injectorConfig && isset($injectorConfig['class']) && $injectorConfig['class'] == MarkdownText::class) {
             $fields->replaceField('Content', MarkdownEditorField::create('Content'));
         }
     }


### PR DESCRIPTION
This is another way to change the HTMLText class's pointer directoly to markdown. So any other modules which uses HTMLText will be converted to Markdown. 

@Firesphere @priyashantha can you take a look at this one please. 