### PR TITLE
Update composer to not use the `silverstripe` prefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "silverstripers/silverstripe-markdown",
+    "name": "silverstripers/markdown",
     "description": "Markdown DB field and form field for SilverStripe",
     "type": "silverstripe-vendormodule",
     "keywords": ["silverstripe", "markdown", "module"],
@@ -21,11 +21,11 @@
             "SilverStripers\\markdown\\shortcodes\\": "src/shortcodes"
         }
     },
-
     "extra": {
         "expose": [
             "client/dist"
-        ]
+        ],
+        "installer-name": "markdown"
     }
     
 }


### PR DESCRIPTION
There is no need for a vendor module to use the `silverstripe-` prefix I believe. The type should make it come up in searches anyway :)