### PR TITLE
FIX Ensure value is cast as string before parsing

### DIFF
--- a/src/db/MarkdownText.php
+++ b/src/db/MarkdownText.php
@@ -57,7 +57,7 @@ class MarkdownText extends DBText
             return $this->parsedContent;
         }
 
-        $parsed = !empty($strValue) ? $strValue : $this->value;
+        $parsed = strval(!empty($strValue) ? $strValue : $this->value);
 
         $this->extend('onBeforeParseDown', $parsed);
 


### PR DESCRIPTION
Getting a few deprecation warnings on PHP8.1 without the value being cast to string as it can be null for empty fields.